### PR TITLE
Change type var order for generated kleisli signatures.

### DIFF
--- a/src/Eff/TH.hs
+++ b/src/Eff/TH.hs
@@ -105,8 +105,9 @@ genSig (GadtC [cName] tArgs' ctrType) = do
       AppT eff tRet    = ctrType
       otherVars        = unapply ctrType
       quantifiedVars   = fmap PlainTV . nub
-                                      $ effs : mapMaybe freeVarName
-                                                        (tArgs ++ otherVars)
+                                      $ mapMaybe freeVarName
+                                                 (tArgs ++ otherVars)
+                                          ++ [effs]
       memberConstraint = ConT ''Member `AppT` eff       `AppT` VarT effs
       resultType       = ConT ''Eff    `AppT` VarT effs `AppT` tRet
 


### PR DESCRIPTION
The logic as it exists adds the `r` type variable as the first element in the `forall` for generated kleisli signatures. Since this type always should be left polymorphic, having it first forces syntactic clutter to apply later type parameters.

Given:

```haskell
data Test t a  where
  GetTest :: Test t t
```

previously:

```haskell
runTest = do
  int <- getTest @_ @Int
```

now:

```haskell
runTest = do
  int <- getTest @Int
```