### PR TITLE
Module name should match file name

### DIFF
--- a/examples/src/HandleRegion.hs
+++ b/examples/src/HandleRegion.hs
@@ -10,7 +10,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans               #-}
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
-module HandleResource where
+module HandleRegion where
 
 import           Control.Exception (SomeException)
 import           Eff (Member, Eff ())


### PR DESCRIPTION
@isovector 

I was getting a build error on stack. Not sure why it didn't show up before, but I believe this module name ought to match the file name. 