### PR TITLE
Fix ocassional omission of TH free vars

### DIFF
--- a/src/Eff/TH.hs
+++ b/src/Eff/TH.hs
@@ -106,12 +106,13 @@ genSig eff (NormalC cName tArgs') = do
 genSig _ (GadtC [cName] tArgs' ctrType) = do
   effs <- newName "effs"
   let fnName           = getDeclName cName
+      desugar          = concatMap unapply $ fmap snd tArgs'
       tArgs            = fmap snd tArgs'
       AppT eff tRet    = ctrType
       otherVars        = unapply ctrType
       quantifiedVars   = fmap PlainTV . nub
                                       $ mapMaybe freeVarName
-                                                 (tArgs ++ otherVars)
+                                                 (desugar ++ otherVars)
                                           ++ [effs]
       memberConstraint = ConT ''Member `AppT` eff       `AppT` VarT effs
       resultType       = ConT ''Eff    `AppT` VarT effs `AppT` tRet


### PR DESCRIPTION
Given the GADT:
```haskell
data Foo a where
  Bar :: Proxy p -> Foo a
```
`$(makeFreer ''Foo)` builds a splice that is missing a `forall` over `p`:

```haskell
    makeFreer ''Foo
  ======>
    bar ::
      forall a_ausW effs_ausX.
      Member Foo effs_ausX => Proxy a_auot -> Eff effs_ausX a_ausW
    bar a_ausY = send (Bar a_ausY)
```

Causing a compiler error (GHC 8.0.2):
```
error:
    The exact Name ‘a_auot’ is not in scope
      Probable cause: you used a unique Template Haskell name (NameU),
      perhaps via newName, but did not bind it
      If that's it, then -ddump-splices might be useful
```

This patch fixes this behaviour.