### PR TITLE
Constrain the kind of `Union`

### DIFF
--- a/src/Data/Open/Union/Internal.hs
+++ b/src/Data/Open/Union/Internal.hs
@@ -58,7 +58,7 @@ import Unsafe.Coerce (unsafeCoerce)
 
 
 -- | Open union is a strong sum (existential with an evidence).
-data Union (r :: [ * -> * ]) a where
+data Union (r :: [ * -> * ]) (a :: *) where
     Union :: {-# UNPACK #-} !Word -> t a -> Union r a
 
 -- | Takes a request of type @t :: * -> *@, and injects it into the 'Union'.


### PR DESCRIPTION
The inferred kind for `Union` in presence of `PolyKinds` was:

`Union :: [* -> *] -> k -> *`

This caused problems with type inference, as the kind variable `k` often
couldn't be determined.